### PR TITLE
MIRIAM annotations

### DIFF
--- a/Toolbox/Core.m
+++ b/Toolbox/Core.m
@@ -484,7 +484,7 @@ attributeTestPatterns={
 	"Name"->_String,
 	"ElementalComposition"->({((_species|_metabolite|_enzyme)->(Automatic|_Times|_Plus|Except["",_String]|_SMILES|_InChI))..}|{}),
 	"Notes"->_String,
-	"Annotations"->{_->{_String..}...},
+	"Annotations"->{(_String->{(_String->{_String..})..})...},
 	"Ignore"->{(_species|_metabolite|_enzyme)..}|{},
 	"UnitChecking"->(True|False),
 	"Synonyms"->{(Join[$MASS$speciesPattern,$MASS$parametersPattern,_v|_String]->_String)..}|{},
@@ -807,7 +807,7 @@ model_MASSmodel["Proteins"]:=Union@Cases[model["GPR"],_protein,\[Infinity]];
 model_MASSmodel["GeneAssociations"]:=(Union[Cases[model["GPR"],r_Rule/;r[[1,0]]===String,\[Infinity]]]/.p_proteinComplex:>And@@p)/.Union[Cases[model["GPR"],r_Rule/;r[[1,0]]===protein||r[[1,0]]===proteinComplex,\[Infinity]]]/.g_geneComplex:>And@@g
 model_MASSmodel["ProteinAssociations"]:=Union[Cases[model["GPR"],r_Rule/;r[[1,0]]===String,\[Infinity]]]/.p_proteinComplex:>And@@p
 model_MASSmodel["Enzymes"]:=Cases[model["Species"],_enzyme];
-model_MASSmodel["Annotations"]:=Null(* FIX ME *);
+model_MASSmodel["Annotations"]:=Null;
 
 
 

--- a/Toolbox/Core.m
+++ b/Toolbox/Core.m
@@ -11,7 +11,7 @@
 Begin["`Private`"];
 
 
-(* ::Subsection:: *)
+(* ::Subsection::Closed:: *)
 (*Util*)
 
 
@@ -172,7 +172,7 @@ wrapHead[stuff_]:=wrap[Head[stuff]]@@stuff
 unwrapHead[stuff_]:=stuff/.w_wrap:>w[[1]]
 
 
-(* ::Subsection:: *)
+(* ::Subsection::Closed:: *)
 (*Warnings and protection*)
 
 
@@ -182,7 +182,7 @@ Toolbox::NotImplemented="Function/Structure `1` has not been implemented yet.";
 Toolbox::deprecated="`1` is deprecated and will be removed in the (very) near future. Please use `2` instead.";
 
 
-(* ::Subsection:: *)
+(* ::Subsection::Closed:: *)
 (*Old routines*)
 
 
@@ -202,7 +202,7 @@ getJacobian[stoich_?MatrixQ,rates_List,mets_List,opts:OptionsPattern[]]:=Module[
 ];
 
 
-(* ::Subsection:: *)
+(* ::Subsection::Closed:: *)
 (*Rates*)
 
 
@@ -260,7 +260,7 @@ kFwd2keq[expression_]:=Simplify[expression/.r_rateconst/;r[[2]]==True:>rateconst
 k2keq[expression_]:=kRev2keq[expression]
 
 
-(* ::Subsection:: *)
+(* ::Subsection::Closed:: *)
 (*PERCs*)
 
 
@@ -308,7 +308,7 @@ calcPERC[model_MASSmodel,steadystateConc:{Rule[$MASS$speciesPattern,_?NumberQ]..
 calcPERC[model_MASSmodel,steadystateConc:{Rule[$MASS$speciesPattern,_?NumberQ]..},steadystateFluxes:{Rule[_String,_?NumberQ]..},equilibriumConstants:{Rule[_Keq,(_?NumberQ|\[Infinity])]..},externalConcentrations:{Rule[$MASS$speciesPattern,(_?NumberQ|\[Infinity])]..}]:=calcPERC[model,"SteadyStateConcentrations"->steadystateConc,"SteadyStateFluxes"->steadystateFluxes,"Parameters"->Join[equilibriumConstants,externalConcentrations]]
 
 
-(* ::Subsection:: *)
+(* ::Subsection::Closed:: *)
 (*Structural stuff*)
 
 
@@ -340,7 +340,7 @@ getDisequilibriumRatios[rxns:{_reaction..},opts:OptionsPattern[]]:=getDisequilib
 calcKappa[rateconstants_List]:=DiagonalMatrix[rateconstants]
 
 
-(* ::Subsection:: *)
+(* ::Subsection::Closed:: *)
 (*Unit support*)
 
 
@@ -484,6 +484,7 @@ attributeTestPatterns={
 	"Name"->_String,
 	"ElementalComposition"->({((_species|_metabolite|_enzyme)->(Automatic|_Times|_Plus|Except["",_String]|_SMILES|_InChI))..}|{}),
 	"Notes"->_String,
+	"Annotations"->{_->{_String..}...},
 	"Ignore"->{(_species|_metabolite|_enzyme)..}|{},
 	"UnitChecking"->(True|False),
 	"Synonyms"->{(Join[$MASS$speciesPattern,$MASS$parametersPattern,_v|_String]->_String)..}|{},
@@ -529,12 +530,12 @@ attributeCallBacks={
 
 Options[constructModel]={"InitialConditions"->{},"Constraints"->{},"Parameters"->{},"Irreversible"->{},"GPR"->{},"CustomRateLaws"->{},
 "CustomODE"->{}(*FIXME needs arg checking*),"Constant"->{},"BoundaryConditions"->{},"Name"->Automatic,"ID"->Automatic,"ElementalComposition"->{},
-"Notes"->"","Ignore"->{},"ReorderStoichiometry"->True,"UnitChecking"->False,"Synonyms"->{},"Events"->{},"Objective"->Automatic};
+"Notes"->"","Annotations"->{},"Ignore"->{},"ReorderStoichiometry"->True,"UnitChecking"->False,"Synonyms"->{},"Events"->{},"Objective"->Automatic};
 constructModel::malformedarg="`1` `2` do/does not match the appropriate pattern `3`";
 constructModel::nonUniqueRxnIDs="Non-unique flux IDs detected for `1`.";
 constructModel::wrongdim="The dimensions of the stoichiometry matrix (`1`) do not match the lengths of the provided compounds (`2`) and flux identifiers (`3`).";
 constructModel::wrongmatrixelements="Non Integer, Real, or Rational elements encountered at positions `1`.";
-constructModel[modelID_String:"",S:(_?MatrixQ|{{}}),compounds:{$MASS$speciesPattern...},fluxes:({(_String|_v)..}|{}),opts:OptionsPattern[]]:=Module[{objective,events,fluxesFinal,variableComp,units,tmpRxns,modelIDtmp,model,contxtStr,constraints,initialConditions,parameters,boundaryConditions,constant,revColInd,irrevConstr,name,notes,exchLeftNull,exchRightNull,exchConstr,elementalComposition,newRowOrder,indepDepS,indepS,linkMatrix,gpr,ignore,pat,defaultInitializationNotes,synonyms},
+constructModel[modelID_String:"",S:(_?MatrixQ|{{}}),compounds:{$MASS$speciesPattern...},fluxes:({(_String|_v)..}|{}),opts:OptionsPattern[]]:=Module[{objective,events,fluxesFinal,variableComp,units,tmpRxns,modelIDtmp,model,contxtStr,constraints,initialConditions,parameters,boundaryConditions,constant,revColInd,irrevConstr,name,notes,annotations,exchLeftNull,exchRightNull,exchConstr,elementalComposition,newRowOrder,indepDepS,indepS,linkMatrix,gpr,ignore,pat,defaultInitializationNotes,synonyms},
 	fluxesFinal=Switch[#,_String,v[#],_v,#,_,v[ToString[#]]]&/@fluxes;
 	
 	If[Length[Union[fluxesFinal]]=!=Length[fluxesFinal],
@@ -598,6 +599,10 @@ constructModel[modelID_String:"",S:(_?MatrixQ|{{}}),compounds:{$MASS$speciesPatt
 
 	notes=OptionValue["Notes"];
 	If[!MatchQ[notes,_String],Message[constructModel::malformedarg,"Notes",Short[notes],"Notes"/.attributeTestPatterns];Abort[]];
+
+	annotations=OptionValue["Annotations"];
+	pat="Annotations"/.attributeTestPatterns;
+	If[!MatchQ[annotations,pat],Message[constructModel::malformedarg,"Annotations",Short[annotations],pat];Abort[]];
 
 	ignore=OptionValue["Ignore"];
 	pat="Ignore"/.attributeTestPatterns;
@@ -666,6 +671,7 @@ constructModel[modelID_String:"",S:(_?MatrixQ|{{}}),compounds:{$MASS$speciesPatt
 			"Name"->name,
 			"ElementalComposition"->elementalComposition,
 			"Notes"->notes,
+			"Annotations"->annotations,
 			"Ignore"->ignore,
 			"UnitChecking"->units,
 			"Synonyms"->synonyms,
@@ -732,7 +738,7 @@ addModelAttribute[model_Symbol,attribute_String,rhs_]:=(AppendTo[model[[1]],attr
 
 (*Attributes*)
 $MASSmodel$MutableAttributes={"ID","Name","Constraints","InitialConditions","Parameters","GPR","BoundaryConditions","HasOnlySubstanceUnits",
-"Constant","ReversibleColumnIndices","CustomRateLaws","CustomODE","ElementalComposition","Notes","Ignore","UnitChecking","Synonyms","Events","Objective"};
+"Constant","ReversibleColumnIndices","CustomRateLaws","CustomODE","ElementalComposition","Notes","Annotations","Ignore","UnitChecking","Synonyms","Events","Objective"};
 $MASSmodel$ImmutableAttributes={"Stoichiometry","Species","Fluxes"};
 $MASSmodel$AdditionalImmutablAttributes={"Attributes","SparseStoichiometry","Reactions","Exchanges","Variables","ForwardRateConstants","ReverseRateConstants",
 "EquilibriumConstants","IrreversibleColumnIndices","Rates","Compartments","ODE","Genes","Proteins","GeneAssociations","ProteinAssociations","Enzymes"}
@@ -801,6 +807,7 @@ model_MASSmodel["Proteins"]:=Union@Cases[model["GPR"],_protein,\[Infinity]];
 model_MASSmodel["GeneAssociations"]:=(Union[Cases[model["GPR"],r_Rule/;r[[1,0]]===String,\[Infinity]]]/.p_proteinComplex:>And@@p)/.Union[Cases[model["GPR"],r_Rule/;r[[1,0]]===protein||r[[1,0]]===proteinComplex,\[Infinity]]]/.g_geneComplex:>And@@g
 model_MASSmodel["ProteinAssociations"]:=Union[Cases[model["GPR"],r_Rule/;r[[1,0]]===String,\[Infinity]]]/.p_proteinComplex:>And@@p
 model_MASSmodel["Enzymes"]:=Cases[model["Species"],_enzyme];
+model_MASSmodel["Annotations"]:=Null(* FIX ME *);
 
 
 

--- a/Toolbox/Core.m
+++ b/Toolbox/Core.m
@@ -493,7 +493,7 @@ annotation2url[annotation_String]:=Module[{},
 	Which[StringMatchQ[annotation,"http://"~~__],
 		Hyperlink[annotation],
 		StringMatchQ[annotation,"urn:miriam:"~~__],
-		Hyperlink[StringReplace[annotation,{"urn:miriam:"->"http://identifiers.org/",":"->"/","%"->":"}]]
+		Hyperlink[annotation,StringReplace[annotation,{"urn:miriam:"->"http://identifiers.org/",":"->"/","%"->":"}]]
 	]
 ];
 

--- a/Toolbox/Core.m
+++ b/Toolbox/Core.m
@@ -480,20 +480,24 @@ displayAnnotations[annotations_List]:=Module[{items,qualifiers,urls,fullItems,fu
 	fullQualifiers = Flatten[MapThread[MapThread[Join[{#1},Table[SpanFromAbove,{i,Length[Flatten[#2]]-1}]]&,{#1,#2}]&,{qualifiers,urls}]];
 	fullURLs = annotation2url/@Flatten[urls];
 
-	title={Item[Style[#,Bold],Alignment->Center]&/@{"Object","Qualifier","URL"}};
-	Grid[Join[title,Transpose@{fullItems,fullQualifiers,fullURLs}],
+	title={Item[Style[#,Bold],Alignment->Center]&/@{"Object","Qualifier","Link"}};
+	Pane[Grid[Join[title,Transpose@{fullItems,fullQualifiers,fullURLs}],
 		Alignment->{Left,Center},
 		Spacings->{1, Automatic},
 		Dividers->All
-	]
+	],{Automatic, 200},Scrollbars->{False, True}]
 ];
 
 
 annotation2url[annotation_String]:=Module[{},
-	Which[StringMatchQ[annotation,"http://"~~__],
-		Hyperlink[annotation],
+	Which[StringMatchQ[annotation,"http://identifiers.org/"~~__],
+		Hyperlink[StringReplace[annotation,"http://identifiers.org"~~__~~"/"->""],
+			annotation
+		],
 		StringMatchQ[annotation,"urn:miriam:"~~__],
-		Hyperlink[annotation,StringReplace[annotation,{"urn:miriam:"->"http://identifiers.org/",":"->"/","%"->":"}]]
+		Hyperlink[StringReplace[annotation,{"urn:miriam:"~~__~~":"->"",":"->"/","%"->":"}],
+			StringReplace[annotation,{"urn:miriam:"->"http://identifiers.org/",":"->"/","%"->":"}]
+		]
 	]
 ];
 
@@ -517,7 +521,7 @@ attributeTestPatterns={
 	"Name"->_String,
 	"ElementalComposition"->({((_species|_metabolite|_enzyme)->(Automatic|_Times|_Plus|Except["",_String]|_SMILES|_InChI))..}|{}),
 	"Notes"->_String,
-	"Annotations"->{(_String->{(_String->{_String..})..})...},
+	"Annotations"->{(_->{(_String->{_String..})..})...},
 	"Ignore"->{(_species|_metabolite|_enzyme)..}|{},
 	"UnitChecking"->(True|False),
 	"Synonyms"->{(Join[$MASS$speciesPattern,$MASS$parametersPattern,_v|_String]->_String)..}|{},

--- a/Toolbox/Core.m
+++ b/Toolbox/Core.m
@@ -11,7 +11,7 @@
 Begin["`Private`"];
 
 
-(* ::Subsection::Closed:: *)
+(* ::Subsection:: *)
 (*Util*)
 
 
@@ -469,8 +469,8 @@ adjustUnits[stuff:{_Rule...},model_MASSmodel,opts:OptionsPattern[]]:=If[model["U
 (*Annotations*)
 
 
-$MIRIAM$modelQualifiers = {"is","isDerivedFrom","isDescribedBy","isInstanceOf","hasInstance"};
-$MIRIAM$biologyQualifiers = {"encodes","hasPart","hasProperty","hasVersion","is","isDescribedBy","isEncodedBy","isHomologTo","isPartOf","isPropertyOf","isVersionOf","occursIn","hasTaxon"};
+$MIRIAM$modelQualifiers = {"is (model)","isDerivedFrom","isDescribedBy (model)","isInstanceOf","hasInstance"};
+$MIRIAM$biologyQualifiers = {"encodes","hasPart","hasProperty","hasVersion","is (biology)","isDescribedBy (biology)","isEncodedBy","isHomologTo","isPartOf","isPropertyOf","isVersionOf","occursIn","hasTaxon"};
 
 
 displayAnnotations[annotations:("Annotations"|{})]:={};

--- a/Toolbox/Core.m
+++ b/Toolbox/Core.m
@@ -469,6 +469,10 @@ adjustUnits[stuff:{_Rule...},model_MASSmodel,opts:OptionsPattern[]]:=If[model["U
 (*Annotations*)
 
 
+$MIRIAM$modelQualifiers = {"is","isDerivedFrom","isDescribedBy","isInstanceOf","hasInstance"};
+$MIRIAM$biologyQualifiers = {"encodes","hasPart","hasProperty","hasVersion","is","isDescribedBy","isEncodedBy","isHomologTo","isPartOf","isPropertyOf","isVersionOf","occursIn","hasTaxon"};
+
+
 displayAnnotations[annotations:("Annotations"|{})]:={};
 
 displayAnnotations[annotations_List]:=Module[{items,qualifiers,urls,fullItems,fullQualifiers,fullURLs,title},

--- a/Toolbox/Core.m
+++ b/Toolbox/Core.m
@@ -470,7 +470,7 @@ adjustUnits[stuff:{_Rule...},model_MASSmodel,opts:OptionsPattern[]]:=If[model["U
 
 
 $MIRIAM$modelQualifiers = {"is (model)","isDerivedFrom","isDescribedBy (model)","isInstanceOf","hasInstance"};
-$MIRIAM$biologyQualifiers = {"encodes","hasPart","hasProperty","hasVersion","is (biology)","isDescribedBy (biology)","isEncodedBy","isHomologTo","isPartOf","isPropertyOf","isVersionOf","occursIn","hasTaxon"};
+$MIRIAM$biologyQualifiers = {"encodes","hasPart","hasProperty","hasVersion","is","isDescribedBy","isEncodedBy","isHomologTo","isPartOf","isPropertyOf","isVersionOf","occursIn","hasTaxon"};
 
 
 displayAnnotations[annotations:("Annotations"|{})]:={};

--- a/Toolbox/IO.m
+++ b/Toolbox/IO.m
@@ -367,7 +367,7 @@ getListOfAnnotations[xml_]:=Module[{lst,miriamList},
 		{___,XMLElement["annotation",{},
 			{___,XMLElement[{_,"RDF"},{___},{a___}],___}
 		],___}
-	]:>AppendTo[lst,{id,a}];
+	]:>AppendTo[lst,{id,a/.{"is"->"is (model)","isDescribedBy"->"isDescribedBy (model)"}}];
 
 	(* Get all compartment annotations *)
 	xml/.XMLElement["compartment",{___,"id"->id_,___},
@@ -400,11 +400,11 @@ getListOfAnnotations[xml_]:=Module[{lst,miriamList},
 	)&/@lst;
 
 	miriamList=miriamList/.{_String,x_String}:>x;
-	First[#]->formatAnnotation[Last[#]]&/@miriamList
+	First[#]->formatRawAnnotation[Last[#]]&/@miriamList
 ];
 
 
-formatAnnotation[miriam_List]:=Module[{raw},
+formatRawAnnotation[miriam_List]:=Module[{raw},
 	raw=First[#]->#[[3,1,3]]&/@miriam;
 	raw/.XMLElement["li",{"resource"->x_},{}]:>x
 ];

--- a/Toolbox/IO.m
+++ b/Toolbox/IO.m
@@ -361,8 +361,8 @@ getParameterValues[listOfParameters:{((_parameter|_parameter[t])->_List)...},uni
 
 getListOfAnnotations[xml_]:=Module[{lst},
 	lst={};
-	xml/.XMLElement[x:Except["model"],{"id"->id_,___},
-		{XMLElement["annotation",{},
+	xml/.XMLElement[x:Except["model"],{___,"id"->id_,___},
+		{___,XMLElement["annotation",{},
 			{___,XMLElement[{_,"RDF"},{___},{a___}],___}
 		],___}
 	]:>AppendTo[lst,{id,a}];
@@ -375,7 +375,7 @@ getListOfAnnotations[xml_]:=Module[{lst},
 formatAnnotation[miriam_XMLElement]:=Module[{raw},
 	raw=First[#]->#[[3,1,3]]&/@miriam[[3]];
 	raw/.XMLElement["li",{"resource"->x_},{}]:>x
-]
+];
 
 
 (* ::Subsubsection:: *)


### PR DESCRIPTION
This branch includes import and export of MIRIAM annotations (through model2sbml and sbml2model) and the new "Annotations" attribute. To view annotations, use `model["Annotations"]`. This will give a table with links to each URN.